### PR TITLE
Allow iptables delete command to fail

### DIFF
--- a/setup/configure.sh
+++ b/setup/configure.sh
@@ -31,7 +31,7 @@ else
 fi
 easyrsa gen-crl
 
-iptables -t nat -D POSTROUTING -s ${OVPN_SRV_NET}/${OVPN_SRV_MASK} ! -d ${OVPN_SRV_NET}/${OVPN_SRV_MASK} -j MASQUERADE
+iptables -t nat -D POSTROUTING -s ${OVPN_SRV_NET}/${OVPN_SRV_MASK} ! -d ${OVPN_SRV_NET}/${OVPN_SRV_MASK} -j MASQUERADE || true
 iptables -t nat -A POSTROUTING -s ${OVPN_SRV_NET}/${OVPN_SRV_MASK} ! -d ${OVPN_SRV_NET}/${OVPN_SRV_MASK} -j MASQUERADE
 
 mkdir -p /dev/net


### PR DESCRIPTION
The `iptables -D` command may fail on first run.
>iptables: No chain/target/match by that name.

This change avoids the issue by allowing it to fail and continuing script execution.
