### PR TITLE
Added support for multi-arch builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,20 @@
 FROM node:16-alpine3.15 AS frontend-builder
 COPY frontend/ /app
-RUN cd /app && npm install && npm run build
+RUN apk add --update python3 make g++ && cd /app && npm install && npm run build
 
 FROM golang:1.17.3-buster AS backend-builder
 RUN go install github.com/gobuffalo/packr/v2/packr2@latest
 COPY --from=frontend-builder /app/static /app/frontend/static
 COPY . /app
-RUN cd /app && packr2 && env CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -a -tags netgo -ldflags '-linkmode external -extldflags -static -s -w' -o ovpn-admin && packr2 clean
+ARG TARGETARCH=amd64
+RUN cd /app && packr2 && env CGO_ENABLED=1 GOOS=linux GOARCH=${TARGETARCH} go build -a -tags netgo -ldflags '-linkmode external -extldflags -static -s -w' -o ovpn-admin && packr2 clean
 
 FROM alpine:3.16
 WORKDIR /app
 COPY --from=backend-builder /app/ovpn-admin /app
+ARG TARGETARCH=amd64
 RUN apk add --update bash easy-rsa openssl openvpn coreutils  && \
     ln -s /usr/share/easy-rsa/easyrsa /usr/local/bin && \
-    wget https://github.com/pashcovich/openvpn-user/releases/download/v1.0.4/openvpn-user-linux-amd64.tar.gz -O - | tar xz -C /usr/local/bin && \
+    wget https://github.com/pashcovich/openvpn-user/releases/download/v1.0.4/openvpn-user-linux-${TARGETARCH}.tar.gz -O - | tar xz -C /usr/local/bin && \
     rm -rf /tmp/* /var/tmp/* /var/cache/apk/* /var/cache/distfiles/*
+RUN if [ -f "/usr/local/bin/openvpn-user-${TARGETARCH}" ]; then ln -s /usr/local/bin/openvpn-user-${TARGETARCH} /usr/local/bin/openvpn-user; fi

--- a/Dockerfile.openvpn
+++ b/Dockerfile.openvpn
@@ -1,7 +1,9 @@
 FROM alpine:3.16
+ARG TARGETARCH=amd64
 RUN apk add --update bash openvpn easy-rsa iptables  && \
     ln -s /usr/share/easy-rsa/easyrsa /usr/local/bin && \
-    wget https://github.com/pashcovich/openvpn-user/releases/download/v1.0.4/openvpn-user-linux-amd64.tar.gz -O - | tar xz -C /usr/local/bin && \
+    wget https://github.com/pashcovich/openvpn-user/releases/download/v1.0.4/openvpn-user-linux-${TARGETARCH}.tar.gz -O - | tar xz -C /usr/local/bin && \
     rm -rf /tmp/* /var/tmp/* /var/cache/apk/* /var/cache/distfiles/*
+RUN if [ -f "/usr/local/bin/openvpn-user-${TARGETARCH}" ]; then ln -s /usr/local/bin/openvpn-user-${TARGETARCH} /usr/local/bin/openvpn-user; fi
 COPY setup/ /etc/openvpn/setup
 RUN chmod +x /etc/openvpn/setup/configure.sh


### PR DESCRIPTION
Added support for multi arch builds.
To build a multi arch image use:

```
docker buildx build --pull --push  --platform linux/amd64,linux/arm64 -t <YOUR_REGISTRY>/openvpn:latest -f Dockerfile.openvpn .
docker buildx build --pull --push  --platform linux/amd64,linux/arm64 -t <YOUR_REGISTRY>/ovpn-admin:latest -f Dockerfile .
```