### PR TITLE
feat: added 2FA configuration and modified readme.md with required instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Simple web UI to manage OpenVPN users, their certificates & routes in Linux. Whi
 * (optionally) Specifying/changing password for additional authorization in OpenVPN;
 * (optionally) Specifying the Kubernetes LoadBalancer if it's used in front of the OpenVPN server (to get an automatically defined `remote` in the `client.conf.tpl` template).
 * (optionally) Storing certificates and other files in Kubernetes Secrets (**Attention, this feature is experimental!**).
+* (optionally) Enabling Google Auth 2FA for each user.
 
 ### Screenshots
 
@@ -63,7 +64,51 @@ cd ovpn-admin
 
 (Please don't forget to configure all needed params in advance.)
 
-### 3. Prebuilt binary
+### 3. Building from source (for enabling google-auth 2FA only)
+
+***Note: This configuration is for enabling 2FA with the admin portal and must be run on the host machine. It will not work in the Docker environment due to compatibility issues with the Google Auth 2FA setup in Docker.***
+
+Requirements. You need Linux with the following components installed:
+- [golang](https://golang.org/doc/install)
+- [packr2](https://github.com/gobuffalo/packr#installation)
+- [nodejs/npm](https://nodejs.org/en/download/package-manager/)
+
+Commands to execute:
+
+```bash
+git clone https://github.com/palark/ovpn-admin.git
+cd ovpn-admin
+./bootstrap.sh
+./build.sh
+./ovpn-admin
+
+./setup/configure.sh
+```
+
+To enable the necessary authentication features, follow these steps:
+
+1. Add the following lines in `templates/client.conf.tpl`:
+   - auth-user-pass
+   - auth-nocache
+   - reneg-sec 0
+
+2. Add the following line in `setup/openvpn.conf`:
+   - plugin /usr/lib/openvpn/openvpn-plugin-auth-pam.so openvpn
+
+3. Set the following varibales with the speicified values in `main.go`
+   ```
+   easyrsaDirPath = /etc/openvpn/easyrsa
+   indexTxtPath = /etc/openvpn/easyrsa/pki/index.txt
+   authDatabase = /etc/openvpn/easyrsa/pki/users.db
+   ccdDir = /etc/openvpn/ccd (if ccdEnabled set to true)
+   ```
+
+4. Set the following varibales with the speicified values in `setup/configure.sh`
+   ```
+   OVPN_2FA=true
+   ```
+
+### 4. Prebuilt binary
 
 You can also download and use prebuilt binaries from the [releases](https://github.com/palark/ovpn-admin/releases/latest) page — just choose a relevant tar.gz file.
 

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -164,6 +164,14 @@ new Vue({
         showForModule: ["core"],
       },
       {
+        name: 'u-download-qrcode',
+        label: 'Download QR Code',
+        class: 'btn-info',
+        showWhenStatus: 'Active',
+        showForServerRole: ['master', 'slave'],
+        showForModule: ["google-auth-2fa"],
+      },
+      {
         name: 'u-edit-ccd',
         label: 'Edit routes',
         class: 'btn-primary',
@@ -271,7 +279,23 @@ new Vue({
         link.click()
         URL.revokeObjectURL(link.href)
       }).catch(console.error);
-    })
+    })   
+    _this.$root.$on('u-download-qrcode', function () {
+      const url = `/api/qr-code/${_this.username}`;
+    
+      axios.get(url, { responseType: 'blob' })
+        .then(function (response) {
+          const blob = new Blob([response.data], { type: 'image/png' });
+    
+          const link = document.createElement('a');
+          link.href = URL.createObjectURL(blob);
+          link.download = _this.username + ".png"; 
+          link.click();
+    
+          URL.revokeObjectURL(link.href);
+        })
+        .catch(console.error);
+    });
     _this.$root.$on('u-edit-ccd', function () {
       _this.u.modalShowCcdVisible = true;
       var data = new URLSearchParams();

--- a/setup/configure.sh
+++ b/setup/configure.sh
@@ -7,6 +7,32 @@ SERVER_CERT="${EASY_RSA_LOC}/pki/issued/server.crt"
 OVPN_SRV_NET=${OVPN_SERVER_NET:-172.16.100.0}
 OVPN_SRV_MASK=${OVPN_SERVER_MASK:-255.255.255.0}
 
+OVPN_PASSWD_AUTH=${OVPN_PASSWD_AUTH:-false}
+OVPN_2FA=false
+GOOGLE_2FA_AUTH_DIR="/etc/google-auth"
+
+if [ ${OVPN_2FA} = "true" ]; then
+  TARGETARCH=$(dpkg --print-architecture) 
+  
+  mkdir -p $EASY_RSA_LOC  
+  sudo apt update -y
+  
+  sudo apt install -y openvpn iptables
+  
+  if [ ! -f "/usr/local/bin/easyrsa" ]; then
+    sudo apt install easy-rsa
+    sudo ln -sf /usr/share/easy-rsa/easyrsa /usr/local/bin/easyrsa
+  fi
+  
+  if [ ! -f "/usr/local/bin/openvpn-user" ]; then
+    cd /tmp
+    wget "https://github.com/pashcovich/openvpn-user/releases/download/v1.0.4/openvpn-user-linux-${TARGETARCH}.tar.gz" -O - | sudo tar xz -C /usr/local/bin
+  fi
+  
+  if [ -f "/usr/local/bin/openvpn-user-${TARGETARCH}" ]; then
+    sudo ln -sf /usr/local/bin/openvpn-user-${TARGETARCH} /usr/local/bin/openvpn-user
+  fi
+fi
 
 cd $EASY_RSA_LOC
 
@@ -39,7 +65,11 @@ if [ ! -c /dev/net/tun ]; then
     mknod /dev/net/tun c 10 200
 fi
 
-cp -f /etc/openvpn/setup/openvpn.conf /etc/openvpn/openvpn.conf
+if [ ${OVPN_2FA} = "true" ]; then
+  cp -f /home/ubuntu/ovpn-admin/setup/openvpn.conf /etc/openvpn/openvpn.conf
+else
+  cp -f /etc/openvpn/setup/openvpn.conf /etc/openvpn/openvpn.conf
+fi
 
 if [ ${OVPN_PASSWD_AUTH} = "true" ]; then
   mkdir -p /etc/openvpn/scripts/
@@ -53,6 +83,61 @@ fi
 
 [ -d $EASY_RSA_LOC/pki ] && chmod 755 $EASY_RSA_LOC/pki
 [ -f $EASY_RSA_LOC/pki/crl.pem ] && chmod 644 $EASY_RSA_LOC/pki/crl.pem
+
+if [ ${OVPN_2FA} = "true" ]; then
+  if [ ! -f "/usr/local/lib/security/pam_google_authenticator.so" ]; then
+    apt update && apt install -y \
+    build-essential \
+    linux-headers-$(uname -r) \
+    autoconf \
+    automake \
+    libtool \
+    cmake \
+    make \
+    git \
+    libpam0g-dev \
+    libpam-google-authenticator \
+    qrencode
+  
+    cd /tmp
+    rm -rf google-authenticator-libpam
+    git clone https://github.com/google/google-authenticator-libpam
+    cd google-authenticator-libpam/
+    ./bootstrap.sh
+    ./configure
+    make
+    make install
+    rm -rf google-authenticator-libpam
+  fi
+  
+  if [ ! -f "/etc/pam.d/openvpn" ]; then
+    bash -c 'cat > /etc/pam.d/openvpn <<EOF
+    auth    requisite       /usr/local/lib/security/pam_google_authenticator.so secret=/etc/google-auth/\${USER}  user=root
+    account    required     pam_permit.so'
+  fi
+  
+  if [ ! -f "/etc/openvpn/google-auth.sh" ]; then
+    sudo mkdir -p /etc/google-auth
+    sudo chown -R root /etc/google-auth
+  
+    sudo bash -c 'cat > /etc/openvpn/google-auth.sh <<EOF
+    #!/bin/bash
+    
+    CLIENT=\$1
+    HOST=\$(hostname)
+    R="\e[0;91m"
+    G="\e[0;92m"
+    W="\e[0;97m"
+    B="\e[1m"
+    C="\e[0m"
+    
+    google-authenticator -t -d -f -r 3 -R 30 -W -C -s "\${GOOGLE_2FA_AUTH_DIR}/\${CLIENT}" || { echo -e "\${R}\${B}error generating QR code\${C}"; exit 1; }
+    secret=\$(head -n 1 "\${GOOGLE_2FA_AUTH_DIR}/\${CLIENT}")
+    qrencode -t PNG -o "\${GOOGLE_2FA_AUTH_DIR}/\${CLIENT}.png" "otpauth://totp/\${CLIENT}@\${HOST}?secret=\${secret}&issuer=openvpn" || { echo -e "\${R}\${B}Error generating PNG\${C}"; exit 1; }'
+    
+    sudo chmod +x $GOOGLE_2FA_AUTH_DIR/google-auth.sh
+  fi
+fi
 
 mkdir -p /etc/openvpn/ccd
 


### PR DESCRIPTION
# Pull Request: Add 2FA Configuration to OpenVPN Admin Portal

## Description:
This pull request introduces two-factor authentication (2FA) configuration to the OpenVPN admin portal. The setup utilizes the **Google Auth PAM OpenVPN plugin** alongside the **google-authenticator** package for enhanced security.

## Key Changes:
- Added 2FA configuration to OpenVPN admin portal using the **Google Auth PAM OpenVPN** plugin.
- Integrated the **google-authenticator** package for generating and validating time-based one-time passwords (TOTP).
- Configured the setup to work exclusively on a **local host machine** (Docker compatibility issues were addressed, and Docker was excluded from this setup).
- Ensured that the changes do not interfere with the existing OpenVPN flow, preserving the current functionality.
- Updated the **README** with instructions for enabling the new 2FA configuration.

## Notes:
- The 2FA configuration works seamlessly when set up on a local machine.
- Docker is not compatible with this 2FA setup at this moment, and the changes were made accordingly to avoid disruptions in the existing flow.
- After enabling the mentioned configuration in the README, the setup should function perfectly.