### PR TITLE
feat(ccd): support IP conflict validation in Kubernetes Secret mode

### DIFF
--- a/kubernetes.go
+++ b/kubernetes.go
@@ -329,10 +329,10 @@ func (openVPNPKI *OpenVPNPKI) easyrsaBuildClient(commonName string) (err error) 
 	secretMetaData := metav1.ObjectMeta{
 		Name: fmt.Sprintf(secretClientTmpl, clientCert.SerialNumber),
 		Labels: map[string]string{
-			"index.txt":                    "",
-			"type":                         "clientAuth",
-			"name":                         commonName,
-			"app.kubernetes.io/managed-by": "ovpn-admin",
+			labelKeyIndexTxt:  "",
+			labelKeyType:      labelValueClientAuth,
+			labelKeyName:      commonName,
+			labelKeyManagedBy: labelValueManagedByApp,
 		},
 		Annotations: map[string]string{
 			"commonName":   commonName,


### PR DESCRIPTION
When running in the Kubernetes environment and using secrets to store user configurations,
the checkStaticAddressIsFree function previously only searched the file system (ccdDir),
ignoring secret-based CCDs. Because of this, the function did not work in the kubernetes cluster.

The function now correctly looks up CCD data in Kubernetes secrets and validates static IP
uniqueness across all users.

This improves correctness and consistency when --storage.backend=kubernetes.secrets is used.

<details>
<summary>Scrennshots</summary>

<img width="1447" height="146" alt="image" src="https://github.com/user-attachments/assets/052e534c-5f76-413b-8ed9-3a0d096d9dbf" />

<img width="627" height="575" alt="image" src="https://github.com/user-attachments/assets/21b64888-4635-4837-b97b-3d883d3f1547" />


</details>

fixes #https://github.com/deckhouse/deckhouse/issues/14367